### PR TITLE
Use org.frege-lang groupId in frege-interpreter-core.

### DIFF
--- a/frege-repl-core/pom.xml
+++ b/frege-repl-core/pom.xml
@@ -83,7 +83,7 @@
             <version>${jline.version}</version>
         </dependency>
         <dependency>
-            <groupId>frege</groupId>
+            <groupId>org.frege-lang</groupId>
             <artifactId>frege-interpreter-core</artifactId>
             <version>${frege.interpreter.version}</version>
         </dependency>


### PR DESCRIPTION
We now use the groupId "org.frege-lang" for frege-interpreter-core
dependency in frege-repl-core pom.xml. Previously we referenced the old
"frege" group which lead to failed builds.

This solves #25.
